### PR TITLE
Correct ascii parsing

### DIFF
--- a/hades.py
+++ b/hades.py
@@ -71,7 +71,7 @@ class Hades:
             for item in pl_items:
                 track_name = item["track"]["name"].replace(" ", "+")
                 artist_name = item["track"]["artists"][0]["name"].replace(" ", "+")
-                pl_tracks.append(f"{track_name}+{artist_name}".encode("utf8"))
+                pl_tracks.append(urllib.parse.quote(f"{track_name}+{artist_name}"))
 
             offset = (offset + len(pl_items))
             pl_items = self.sp.playlist_items(


### PR DESCRIPTION
This would fix #14 

The _strange_ characters are encoded by `urllib` to produce a correct search URL for YouTube

e.g. for `De mon âme à ton âme`
before: [https://www.youtube.com/results?search_query=b'De+mon+\xc3\xa2me+\xc3\xa0+ton+\xc3\xa2me+KOMPROMAT'](https://www.youtube.com/results?search_query=b'De+mon+\xc3\xa2me+\xc3\xa0+ton+\xc3\xa2me+KOMPROMAT')
after: [https://www.youtube.com/results?search_query=De%2Bmon%2B%C3%A2me%2B%C3%A0%2Bton%2B%C3%A2me%2BKOMPROMAT](https://www.youtube.com/results?search_query=De%2Bmon%2B%C3%A2me%2B%C3%A0%2Bton%2B%C3%A2me%2BKOMPROMAT)