### PR TITLE
Add prerequisites for FFmpeg installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
  This script takes a Spotify playlist, list and search each track on youtube and
  download it to the specified path with the script root path as parent
  
+## Prerequisites 
+Hades requires an installation of FFmpeg. Download for [Windows](https://www.wikihow.com/Install-FFmpeg-on-Windows), and for [UNIX](https://www.ffmpeg.org/download.html).
+ 
 ## Installing
 To use **Hades** you need to create an App on the [Spotify Developers Dashboard](https://developer.spotify.com/dashboard/applications) and setup your `CLIENT_ID` and `CLIENT_SECRET` as environment variables to connect to the Spotify API. In order to list and download your own playlists you also need to setup your `USER_ID` in your environment variables.
 


### PR DESCRIPTION
Hades requires FFmpeg to prevent terminal error (tested on Windows 10) when converting .M4A and .WEBM to .MP3