### PR TITLE
Add further replacement of special characters

### DIFF
--- a/hades.py
+++ b/hades.py
@@ -56,7 +56,7 @@ class Hades:
         ]
 
     def normalize_str(self, string):
-        return string.replace("/", "_").replace('"', " ")
+        return string.translate(str.maketrans("\\/:*?\"<>|", "__       "))
 
     def get_playlist_details(self, pl_uri):
         offset = 0


### PR DESCRIPTION
Fixes #24 where special characters, `'\','/',':','*','?','"','<','>','|'`, would crash the program.
Now special characters that aren't allowed on file names get replaced with either "_" or " ". 

This could potentially cause problems if songs are entirely named with special characters:
For [example](https://open.spotify.com/track/3xsqVzOwQIF3cx1BUOXfwr?si=780976e322844e5f), would be named `EDEN -     .mp3`. 
I invite anyone to find a solution that would work in that case